### PR TITLE
Split production deployment into two jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test building the docker image
         run: docker build .

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -17,7 +17,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Perform pre-release actions
         uses: danielemery/github-release-action/perform-pre-release@main # TODO target a static release

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -9,16 +9,14 @@ concurrency:
   group: "prod-deployment"
 
 jobs:
-  deploy-production:
+  prepare-production-deployment:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
-      contents: write # Write is required to create/update releases
-    environment: production
+      contents: write # Write is required to create a draft release
+    outputs:
+      release-id: ${{ steps.pre_release.outputs.release-id }}
+      is-existing-release: ${{ steps.pre_release.outputs.is-existing-release }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Perform pre-release actions
         uses: danielemery/github-release-action/perform-pre-release@main # TODO target a static release
         id: pre_release
@@ -26,11 +24,21 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           release-version: ${{github.ref_name}}
 
-      # TODO remove
-      - name: Echo the outputs from the pre-release action
+      - name: Echo the outputs
         run: |
           echo "releaseId: ${{ steps.pre_release.outputs.release-id }}"
           echo "isExistingRelease: ${{ steps.pre_release.outputs.is-existing-release }}"
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    needs: prepare-production-deployment
+    permissions:
+      packages: write
+      contents: write # Write is required to delete intermediate releases and publish the final release
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -51,4 +59,4 @@ jobs:
         uses: danielemery/github-release-action/perform-post-release@main # TODO target a static release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-id: ${{ steps.pre_release.outputs.release-id }}
+          release-id: ${{ needs.prepare-production-deployment.outputs.release-id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     environment: staging
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate version based on date
         run: echo "RELEASE_VERSION=$(date '+%Y-%m-%d_%H_%M')" >> $GITHUB_ENV


### PR DESCRIPTION
- Splits the production pre-deployment step and the actual deployment step so that only the second part requires approval
- Bumps actions/checkout